### PR TITLE
PR for https://github.com/pitchmuc/aepp/issues/12 and https://github.com/pitchmuc/aepp/issues/14

### DIFF
--- a/aepp/config.py
+++ b/aepp/config.py
@@ -6,10 +6,12 @@ config_object = {
     "tech_id": "",
     "pathToKey": "",
     "secret": "",
-    "date_limit" : 0,
+    "date_limit": 0,
     "sandbox": "",
+    "environment": "",
     "token": "",
-    "tokenEndpoint" : "https://ims-na1.adobelogin.com/ims/exchange/jwt"
+    "tokenEndpoint": "",
+    "imsEndpoint": ""
 }
 
 header = {"Accept": "application/json",
@@ -22,7 +24,8 @@ header = {"Accept": "application/json",
 
 # endpoints
 endpoints = {
-    "global": "https://platform.adobe.io",
+    # global endpoint is https://platform.adobe.io in prod, otherwise https://platform-$ENV.adobe.io
+    "global": "",
     "schemas": "/data/foundation/schemaregistry",
     "query": "/data/foundation/query",
     "catalog": "/data/foundation/catalog",
@@ -34,17 +37,17 @@ endpoints = {
     "sensei": "/data/sensei",
     "access": "/data/foundation/access-control",
     "flow": "/data/foundation/flowservice",
-    "privacy":"/data/core/privacy",
+    "privacy": "/data/core/privacy",
     "dataaccess": "/data/foundation/export",
-    "mapping":"/data/foundation/conversion",
-    "policy":"/data/foundation/dulepolicy",
-    "dataset":"/data/foundation/dataset",
-    "ingestion":"/data/foundation/import",
-    "observability":"/data/infrastructure/observability/insights",
-    "destinationAuthoring" : "/data/core/activation/authoring",
+    "mapping": "/data/foundation/conversion",
+    "policy": "/data/foundation/dulepolicy",
+    "dataset": "/data/foundation/dataset",
+    "ingestion": "/data/foundation/import",
+    "observability": "/data/infrastructure/observability/insights",
+    "destinationAuthoring": "/data/core/activation/authoring",
     "streaming": {
-        "inlet": "https://platform.adobe.io/data/core/edge",
-        "collection" : "https://dcs.adobedc.net"
+        "inlet": "",
+        "collection": "https://dcs.adobedc.net"
     },
-    "audit":"/data/foundation"
+    "audit": "/data/foundation"
 }

--- a/aepp/connector.py
+++ b/aepp/connector.py
@@ -113,14 +113,14 @@ class AdobeRequest:
             "exp": now_plus_24h,
             "iss": config["org_id"],
             "sub": config["tech_id"],
-            "https://ims-na1.adobelogin.com/s/ent_dataservices_sdk": True,
-            "aud": f'https://ims-na1.adobelogin.com/c/{config["client_id"]}',
+            f"{self.config['imsEndpoint']}/s/ent_dataservices_sdk": True,
+            "aud": f'{self.config["imsEndpoint"]}/c/{config["client_id"]}',
         }
         # privacy topic
         if kwargs.get("privacyScope", False):
-            jwt_payload["https://ims-na1.adobelogin.com/s/ent_gdpr_sdk"] = True
+            jwt_payload[f"{self.config['imsEndpoint']}/s/ent_gdpr_sdk"] = True
         if kwargs.get("aepScope", True) == False:
-            del jwt_payload["https://ims-na1.adobelogin.com/s/ent_dataservices_sdk"]
+            del jwt_payload[f"{self.config['imsEndpoint']}/s/ent_dataservices_sdk"]
         encoded_jwt = self._get_jwt(payload=jwt_payload, private_key=private_key)
 
         payload = {

--- a/aepp/flowservice.py
+++ b/aepp/flowservice.py
@@ -510,12 +510,14 @@ class FlowService:
                     target_connection_id
                 ],
                 "transformations": [],
-                "scheduleParams": {
-                    "startTime": schedule_start_time,
-                    "frequency": schedule_frequency,
-                    "interval": str(schedule_interval)
-                }
+                "scheduleParams": {}
             }
+            if schedule_start_time is not None:
+                obj["scheduleParams"]["startTime"] = schedule_start_time
+            if schedule_frequency is not None:
+                obj["scheduleParams"]["frequency"] = schedule_frequency
+            if schedule_interval is not None:
+                obj["scheduleParams"]["interval"] = str(schedule_interval)
             if transformation_mapping_id is not None:
                 obj["transformations"] = [
                     {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,11 +41,18 @@ Normally your config file will look like this:
     "tech_id": "<something>@techacct.adobe.com",
     "secret": "<YourSecret>",
     "pathToKey": "<path/to/your/privatekey.key>",
-    "sandbox-name": "prod"
+    "sandbox-name": "prod",
+    "environment": "prod"
 }
 ```
 
-**Note** By default, we are setting the sandbox name to "prod". If you don't know what that value, you can override it via a paramter.
+**Note** By default, we are setting the sandbox name to "prod". If you don't know what that value, you can override it via a parameter.
+
+### Environments
+
+By default, the environment is set to `prod`. This is different from the sandbox, as it refers to the physical environment where the organization was setup.
+
+For all AEP customers "prod" is what should be used, but for internal accounts it can be set to "stage" or "int".
 
 ### Importing the config file and working with a sub module
 
@@ -64,18 +71,35 @@ In that case, you can directly pass the elements in the configure method.
 
 ```python
 import aepp
-aepp.configure(org_id=my_org_id,tech_id=my_tech_id, secret=my_secret,path_to_key=my_path_to_key,client_id=my_client_id)
+aepp.configure(
+    org_id=my_org_id,
+    tech_id=my_tech_id, 
+    secret=my_secret,
+    path_to_key=my_path_to_key,
+    client_id=my_client_id,
+    environment="prod"
+)
 ```
 
 In case you do not want to use a private.key file, you can also provide the private key as a string.
 
 ```python
 import aepp
-aepp.configure(org_id=my_org_id,tech_id=my_tech_id, secret=my_secret,private_key=my_key_as_string,client_id=my_client_id)
+aepp.configure(
+    org_id=my_org_id,
+    tech_id=my_tech_id, 
+    secret=my_secret,
+    private_key=my_key_as_string,
+    client_id=my_client_id,
+    environment="prod"
+)
 ```
 
 **NOTE** : In both case, I didn't provide a `sandbox` parameter but this parameter does exist and can be used to setup a specific sandbox.\
 By default, the prod sandbox will be used.
+
+**NOTE** The `environment` parameter is optional and defaults to "prod".
+
 
 ### Importing a module to work with
 


### PR DESCRIPTION
- Use the environment in the platform global endpoint
- Use the stage IMS endpoint for non-prod environments
- Update README
- Update the `flowservice` module to support dataset egress
- Update the `flowservice` module to look the connection spec IDs from API instead of hardcoding them

I have tested it on orgs in stage and it works as intended.

Related issues:
- https://github.com/pitchmuc/aepp/issues/14
- https://github.com/pitchmuc/aepp/issues/12