### PR TITLE
Support for non-user tokens

### DIFF
--- a/aepp/config.py
+++ b/aepp/config.py
@@ -5,12 +5,14 @@ config_object = {
     "client_id": "",
     "tech_id": "",
     "pathToKey": "",
+    "auth_code": "",
     "secret": "",
     "date_limit": 0,
     "sandbox": "",
     "environment": "",
     "token": "",
-    "tokenEndpoint": "",
+    "jwtTokenEndpoint": "",
+    "oathTokenEndpoint": "",
     "imsEndpoint": ""
 }
 

--- a/aepp/sandboxes.py
+++ b/aepp/sandboxes.py
@@ -128,6 +128,14 @@ class Sandboxes:
         res = self.connector.getData(path)
         return res
 
+    def getSandboxId(self, name: str) -> str:
+        """
+        Retrieve the ID of a sandbox by name.
+        Argument:
+            name : REQUIRED : name of Sandbox
+        """
+        return self.getSandbox(name)["id"]
+
     def deleteSandbox(self, name: str) -> dict:
         """
         Delete a sandbox by its name.


### PR DESCRIPTION
This PR is to support non-user tokens without JWT where we can specify just the client ID, secret and an authorization code (permanent or short-lived)

I tested it in prod and stage on multiple orgs, using both the current JWT-based authentication and this new method, and all work. Not adding unit tests as we will discuss unit tests initiative for this repo separately using mocking.

Related issues: 
- https://github.com/pitchmuc/aepp/issues/9