### PR TITLE
add sandbox reset request payload

### DIFF
--- a/aepp/sandboxes.py
+++ b/aepp/sandboxes.py
@@ -161,7 +161,7 @@ class Sandboxes:
         if self.loggingEnabled:
             self.logger.debug(f"Starting resetSandbox")
         path = self.endpoint + f"/sandboxes/{name}"
-        res = self.connector.putData(path)
+        res = self.connector.putData(path, data={'action':'reset'})
         return res
 
     def updateSandbox(self, name: str, action: dict = None) -> dict:


### PR DESCRIPTION
According to public documentation, the sandbox reset request needs a payload that is currently missing: https://experienceleague.adobe.com/docs/experience-platform/sandbox/api/sandboxes.html?lang=en#reset