### PR TITLE
adding conditions for robustness of schema and field group managers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     description="Package to manage AEP API endpoint and some helper functions",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/pitchmuc/aep",
+    url="https://github.com/adobe/aepp",
     packages=setuptools.find_packages(),
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Issues were araising when you use Schema or Field Group Manager and an issue during the creation or update of the schema or field group. 
It was replacing the definition with the error object. 
Condition is now checking that the request succeed before replacing the internal object. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
