### PR TITLE
Raise exception when data is None OR (instead of AND) data is not Dict on streamMessage

### DIFF
--- a/aepp/ingestion.py
+++ b/aepp/ingestion.py
@@ -453,7 +453,7 @@ class DataIngestion:
         privateHeader = deepcopy(self.header)
         if inletId is None:
             raise Exception("Require a connectionId to be present")
-        if data is None and type(data) != list:
+        if data is None or type(data) != list:
             raise Exception("Require a list of dictionary to be send for ingestion")
         if flowId is not None:
             privateHeader['x-adobe-flow-id'] = flowId


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changing the logic from `data is None and type(data) != dict` into `data is None or type(data) != dict`. This will ensure when data is actually exists and not a dict (a potential common mistake is probably to make data a string instead) it will raise an exception.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/pitchmuc/aepp/issues/52
## Motivation and Context
Better validation for the data type.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
