### PR TITLE
#54 GET Schema API return empty list when 'start' parameter is provided

### DIFF
--- a/aepp/schema.py
+++ b/aepp/schema.py
@@ -254,8 +254,9 @@ class Schema:
         if self.loggingEnabled:
             self.logger.debug(f"Starting getSchemas")
         path = f"/{self.container}/schemas/"
-        start = kwargs.get("start", 0)
-        params = {"start": start}
+        params = {}
+        if(kwargs.get("start")):
+            params["start"] = kwargs.get("start")
         if classFilter is not None:
             params["property"] = f"meta:intendedToExtend=={classFilter}"
         if excludeAdhoc:


### PR DESCRIPTION
Check if start parameter is provided, if not then by pass it.

<!--- Provide a general summary of your changes in the Title above -->

## Description

We are trying to use Aepp wrapper in order to automate the provisioning of the schemas, etc.
However when we try to use the it we noticed that AEPP wrapper is supplying a start parameter. When the start parameter is not provided from the request the default is set to 0. So either way the start parameter is provided. In this case the result is an empty list as it expects other parameters such as order by etc. 
So in this case I propose to check whether the start parameter is provided and only then to be added to the param list.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

https://github.com/pitchmuc/aepp/issues/54

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
